### PR TITLE
feat(summary,exclude): display excluded files in summary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,31 @@ on:
     branches: [main]
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.changes.outputs.changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for changes
+        uses: ./
+        with:
+          include: "**/*.md,**/*.yml"
+          exclude: "**/node_modules/**/*"
+          list-files: json
+
+      - name: Verify outputs
+        run: |
+          echo "Changed: ${{ steps.changes.outputs.changed }}"
+          echo "Count: ${{ steps.changes.outputs.changes_count }}"
+          echo "Files: ${{ steps.changes.outputs.changed_files }}"
+
   test:
     runs-on: ubuntu-latest
+    needs: check_changes
+    if: needs.check_changes.outputs.changed == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,6 +51,8 @@ jobs:
   # Test the action itself
   test-action:
     runs-on: ubuntu-latest
+    needs: check_changes
+    if: needs.check_changes.outputs.changed == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,6 +92,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    needs: check_changes
+    if: needs.check_changes.outputs.changed == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   check_changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       changed: ${{ steps.changes.outputs.changed }}
     steps:
@@ -18,9 +20,15 @@ jobs:
       - name: Check for changes
         uses: ./
         with:
-          include: "**/*.md,**/*.yml"
-          exclude: "**/node_modules/**/*"
-          list-files: json
+          base: ${{ github.event_name == 'push' && github.event.before || '' }}
+          include: "**/*"
+          exclude: |
+            **/*.md
+            .gitignore
+            .gitattributes
+            .vscode/**/*
+            renovate.json
+          summary: true
 
       - name: Verify outputs
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,13 @@ jobs:
     permissions:
       contents: read
     outputs:
-      changed: ${{ steps.changes.outputs.changed }}
+      changed: ${{ steps.filter.outputs.changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Check for changes
+        id: filter
         uses: ./
         with:
           base: ${{ github.event_name == 'push' && github.event.before || '' }}

--- a/check-changes.sh
+++ b/check-changes.sh
@@ -229,6 +229,7 @@ if [[ "$(printf '%s' "$INPUT_SUMMARY" | tr '[:upper:]' '[:lower:]')" == "true" ]
       fi
     fi
     if [[ ${#excluded_files[@]} -gt 0 ]]; then
+      mapfile -t excluded_files < <(printf "%s\n" "${excluded_files[@]}" | sort)
       echo ""
       if [[ ${#excluded_files[@]} -gt 10 ]]; then
         echo "<details><summary>Excluded Files (${#excluded_files[@]})</summary>"


### PR DESCRIPTION
The GitHub Actions summary now includes a list of files explicitly excluded by the 'exclude' input patterns. This gives better visibility into the script's behavior by showing which files were changed and which were ignored.

- Differentiates between files excluded via 'exclude' patterns and files that do not match any 'include' patterns.
- The summary lists any files that were changed but then excluded.
- For summaries with >10 excluded files, the list is rendered in a collapsible block for readability.